### PR TITLE
Fix backdrop remaining after submitting the Subscribe to a Feed dialog

### DIFF
--- a/app/assets/javascripts/ng-controllers/ng-FeedbunchCtrl.js.coffee
+++ b/app/assets/javascripts/ng-controllers/ng-FeedbunchCtrl.js.coffee
@@ -89,6 +89,11 @@ highlightedEntrySvc, highlightedSidebarLinkSvc, formFocusSvc)->
   #--------------------------------------------
   $scope.subscribe = (e)->
     $("#subscribe-feed-popup").modal 'hide'
+
+    # There seems to be a bug in Bootstrap in which the backdrop can remain. See
+    # http://competa.com/blog/2013/11/how-to-stop-twitter-bootstrap-modal-dialogs-breaking-on-browser-history-navigation-in-angularjs/
+    $('.modal-backdrop').remove();
+
     subscriptionSvc.subscribe $scope.subscription_url
     $scope.subscription_url = null
     e.preventDefault()


### PR DESCRIPTION
Due to a Twitter Bootstrap issue, sometimes after a modal is hidden, the backdrop remains. Workaround it by removing all backdrops after hiding. More details here:
http://competa.com/blog/2013/11/how-to-stop-twitter-bootstrap-modal-dialogs-breaking-on-browser-history-navigation-in-angularjs/