### PR TITLE
Remove private call on FolderManager as those methods are being called elsewhere

### DIFF
--- a/app/clients/s3_client.rb
+++ b/app/clients/s3_client.rb
@@ -94,8 +94,6 @@ class S3Client
     return exists
   end
 
-  private
-
   ##
   # Get a file's S3 key, which can be used with the AWS API to operate on the file.
   # Receives as arguments:

--- a/lib/folder_manager.rb
+++ b/lib/folder_manager.rb
@@ -101,8 +101,6 @@ class FolderManager
     return folder
   end
 
-  private
-
   ##
   # Move a feed to an existing folder.
   #


### PR DESCRIPTION
The methods defined below the `private` definition aren't really private as they are being called in other files. On `User#move_feed_to_folder` for example.